### PR TITLE
Add OpenAI-compatible provider support with custom endpoints

### DIFF
--- a/src/components/features/settings/AISettings.css
+++ b/src/components/features/settings/AISettings.css
@@ -81,6 +81,27 @@
   border-color: var(--accent-primary);
 }
 
+.ai-settings__custom-model-toggle {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  margin-bottom: var(--spacing-sm);
+  font-size: var(--font-size-sm);
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+
+.ai-settings__custom-model-toggle input[type="checkbox"] {
+  accent-color: var(--accent-primary);
+}
+
+.ai-settings__hint {
+  margin: var(--spacing-xs) 0 0;
+  font-size: var(--font-size-xs);
+  color: var(--text-tertiary);
+  line-height: 1.5;
+}
+
 .ai-settings__actions {
   display: flex;
   gap: var(--spacing-sm);

--- a/src/components/features/settings/AISettings.tsx
+++ b/src/components/features/settings/AISettings.tsx
@@ -12,21 +12,51 @@ export function AISettings() {
   const [provider, setProvider] = useState<AIProvider>(config?.provider ?? 'openai');
   const [apiKey, setApiKey] = useState(config?.apiKey ?? '');
   const [model, setModel] = useState(config?.model ?? getProviderMeta('openai').defaultModel);
+  const [customEndpoint, setCustomEndpoint] = useState(config?.customEndpoint ?? '');
+  const [useCustomModel, setUseCustomModel] = useState(() => {
+    if (!config) return false;
+    const meta = getProviderMeta(config.provider);
+    if (meta.models.length === 0) return false;
+    return !meta.models.some((m) => m.id === config.model);
+  });
   const [showKey, setShowKey] = useState(false);
   const [testStatus, setTestStatus] = useState<'idle' | 'testing' | 'success' | 'error'>('idle');
   const [testError, setTestError] = useState('');
 
   const providerMeta = getProviderMeta(provider);
+  const isOpenAICompatible = provider === 'openai-compatible';
+  const hasPresetModels = providerMeta.models.length > 0;
 
   const handleProviderChange = (newProvider: AIProvider) => {
     setProvider(newProvider);
     const meta = getProviderMeta(newProvider);
-    setModel(meta.defaultModel);
+    if (meta.models.length > 0) {
+      setModel(meta.defaultModel);
+      setUseCustomModel(false);
+    } else {
+      setModel('');
+      setUseCustomModel(false);
+    }
+    setTestStatus('idle');
+  };
+
+  const handleCustomModelToggle = (checked: boolean) => {
+    setUseCustomModel(checked);
+    if (!checked && hasPresetModels) {
+      setModel(providerMeta.defaultModel);
+    } else if (checked) {
+      setModel('');
+    }
     setTestStatus('idle');
   };
 
   const handleSave = () => {
-    saveConfig({ provider, apiKey, model });
+    saveConfig({
+      provider,
+      apiKey,
+      model,
+      ...(isOpenAICompatible ? { customEndpoint } : {}),
+    });
     setTestStatus('idle');
   };
 
@@ -35,6 +65,8 @@ export function AISettings() {
     setApiKey('');
     setProvider('openai');
     setModel(getProviderMeta('openai').defaultModel);
+    setCustomEndpoint('');
+    setUseCustomModel(false);
     setShowKey(false);
     setTestStatus('idle');
   };
@@ -44,13 +76,20 @@ export function AISettings() {
     setTestStatus('testing');
     setTestError('');
     try {
-      await testConnection({ provider, apiKey, model });
+      await testConnection({
+        provider,
+        apiKey,
+        model,
+        ...(isOpenAICompatible ? { customEndpoint } : {}),
+      });
       setTestStatus('success');
     } catch (err) {
       setTestStatus('error');
       setTestError(err instanceof Error ? err.message : '接続に失敗しました');
     }
   };
+
+  const canSave = apiKey && model && (!isOpenAICompatible || customEndpoint);
 
   return (
     <div className="ai-settings">
@@ -71,6 +110,22 @@ export function AISettings() {
           ))}
         </div>
       </div>
+
+      {isOpenAICompatible && (
+        <div className="ai-settings__section">
+          <h3 className="ai-settings__section-title">エンドポイントURL</h3>
+          <input
+            type="text"
+            value={customEndpoint}
+            onChange={(e) => { setCustomEndpoint(e.target.value); setTestStatus('idle'); }}
+            placeholder="https://openrouter.ai/api/v1"
+            className="ai-settings__input"
+          />
+          <p className="ai-settings__hint">
+            OpenAI互換の /v1/chat/completions エンドポイントを持つサービスのベースURLを入力してください。
+          </p>
+        </div>
+      )}
 
       <div className="ai-settings__section">
         <h3 className="ai-settings__section-title">APIキー</h3>
@@ -95,15 +150,35 @@ export function AISettings() {
 
       <div className="ai-settings__section">
         <h3 className="ai-settings__section-title">モデル</h3>
-        <select
-          value={model}
-          onChange={(e) => { setModel(e.target.value); setTestStatus('idle'); }}
-          className="ai-settings__select"
-        >
-          {providerMeta.models.map((m) => (
-            <option key={m.id} value={m.id}>{m.name}</option>
-          ))}
-        </select>
+        {hasPresetModels && (
+          <label className="ai-settings__custom-model-toggle">
+            <input
+              type="checkbox"
+              checked={useCustomModel}
+              onChange={(e) => handleCustomModelToggle(e.target.checked)}
+            />
+            <span>その他（自由入力）</span>
+          </label>
+        )}
+        {hasPresetModels && !useCustomModel ? (
+          <select
+            value={model}
+            onChange={(e) => { setModel(e.target.value); setTestStatus('idle'); }}
+            className="ai-settings__select"
+          >
+            {providerMeta.models.map((m) => (
+              <option key={m.id} value={m.id}>{m.name}</option>
+            ))}
+          </select>
+        ) : (
+          <input
+            type="text"
+            value={model}
+            onChange={(e) => { setModel(e.target.value); setTestStatus('idle'); }}
+            placeholder="モデルIDを入力（例: gpt-4o, claude-sonnet-4-20250514）"
+            className="ai-settings__input"
+          />
+        )}
       </div>
 
       <div className="ai-settings__actions">
@@ -111,7 +186,7 @@ export function AISettings() {
           variant="outline"
           size="medium"
           onClick={handleTest}
-          disabled={!apiKey || testStatus === 'testing'}
+          disabled={!canSave || testStatus === 'testing'}
         >
           {testStatus === 'testing' ? '接続テスト中...' : '接続テスト'}
         </Button>
@@ -119,7 +194,7 @@ export function AISettings() {
           variant="primary"
           size="medium"
           onClick={handleSave}
-          disabled={!apiKey}
+          disabled={!canSave}
         >
           保存
         </Button>

--- a/src/constants/ai.ts
+++ b/src/constants/ai.ts
@@ -30,6 +30,12 @@ export const AI_PROVIDERS: AIProviderMeta[] = [
     ],
     defaultModel: 'gemini-2.5-flash',
   },
+  {
+    id: 'openai-compatible',
+    name: 'OpenAI互換',
+    models: [],
+    defaultModel: '',
+  },
 ];
 
 export const AI_CONFIG_STORAGE_KEY = 'profit-calendar-ai-config';

--- a/src/hooks/useAIConfig.ts
+++ b/src/hooks/useAIConfig.ts
@@ -27,7 +27,11 @@ export function useAIConfig() {
 
   return {
     config,
-    isConfigured: config !== null && config.apiKey.length > 0,
+    isConfigured:
+      config !== null &&
+      config.apiKey.length > 0 &&
+      config.model.length > 0 &&
+      (config.provider !== 'openai-compatible' || (config.customEndpoint ?? '').length > 0),
     saveConfig,
     clearConfig,
   } as const;

--- a/src/services/aiService.ts
+++ b/src/services/aiService.ts
@@ -4,7 +4,8 @@ interface ProviderStrategy {
   buildRequest(
     prompt: string,
     model: string,
-    apiKey: string
+    apiKey: string,
+    customEndpoint?: string
   ): { url: string; init: RequestInit };
   parseResponse(json: unknown): string;
 }
@@ -99,11 +100,41 @@ const gemini: ProviderStrategy = {
   },
 };
 
+// ---------- OpenAI Compatible ----------
+const openaiCompatible: ProviderStrategy = {
+  buildRequest(prompt, model, apiKey, customEndpoint) {
+    const baseUrl = (customEndpoint ?? '').replace(/\/+$/, '');
+    if (!baseUrl) throw new Error('OpenAI互換: エンドポイントURLが設定されていません');
+
+    const url = baseUrl.endsWith('/chat/completions')
+      ? baseUrl
+      : `${baseUrl}/chat/completions`;
+
+    return {
+      url,
+      init: {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${apiKey}`,
+        },
+        body: JSON.stringify({
+          model,
+          messages: [{ role: 'user', content: prompt }],
+          temperature: 0.7,
+        }),
+      },
+    };
+  },
+  parseResponse: openai.parseResponse,
+};
+
 // ---------- Strategy Map ----------
 const strategies: Record<AIProvider, ProviderStrategy> = {
   openai,
   anthropic,
   gemini,
+  'openai-compatible': openaiCompatible,
 };
 
 // ---------- Public API ----------
@@ -115,7 +146,7 @@ export async function analyzeWithAI(
 ): Promise<string> {
   const strategy = strategies[config.provider];
   const fullPrompt = `${promptText}\n\n## 統計データ (JSON)\n\`\`\`json\n${statisticsJson}\n\`\`\``;
-  const { url, init } = strategy.buildRequest(fullPrompt, config.model, config.apiKey);
+  const { url, init } = strategy.buildRequest(fullPrompt, config.model, config.apiKey, config.customEndpoint);
 
   const response = await fetch(url, init);
   const json: unknown = await response.json();
@@ -133,7 +164,7 @@ export async function analyzeWithAI(
 
 export async function testConnection(config: AIConfig): Promise<void> {
   const strategy = strategies[config.provider];
-  const { url, init } = strategy.buildRequest('Hello', config.model, config.apiKey);
+  const { url, init } = strategy.buildRequest('Hello', config.model, config.apiKey, config.customEndpoint);
 
   const response = await fetch(url, init);
   const json: unknown = await response.json();

--- a/src/types/ai.ts
+++ b/src/types/ai.ts
@@ -1,9 +1,10 @@
-export type AIProvider = 'openai' | 'anthropic' | 'gemini';
+export type AIProvider = 'openai' | 'anthropic' | 'gemini' | 'openai-compatible';
 
 export interface AIConfig {
   provider: AIProvider;
   apiKey: string;
   model: string;
+  customEndpoint?: string;
 }
 
 export interface AIProviderMeta {


### PR DESCRIPTION
## Summary
This PR adds support for OpenAI-compatible API providers (like OpenRouter, Together AI, etc.) by introducing a new provider type that allows users to specify custom endpoints and model names.

## Key Changes

- **New Provider Type**: Added `'openai-compatible'` as a new AI provider option alongside existing OpenAI, Anthropic, and Gemini providers
- **Custom Endpoint Support**: Users can now specify a custom API endpoint URL when using OpenAI-compatible providers
- **Custom Model Input**: Added ability to enter custom model IDs manually, with a toggle to switch between preset models (when available) and free-form text input
- **Enhanced Validation**: Updated configuration validation to require `customEndpoint` for OpenAI-compatible providers
- **Provider Strategy**: Implemented `openaiCompatible` strategy in `aiService.ts` that constructs requests compatible with OpenAI's API format

## Implementation Details

- The `AISettings` component now includes:
  - A new section for entering custom endpoint URLs (only visible for OpenAI-compatible provider)
  - A checkbox toggle to switch between preset models and custom model input
  - Updated save/test button validation to require endpoint URL for compatible providers
  
- The `openaiCompatible` strategy:
  - Accepts optional `customEndpoint` parameter
  - Normalizes the endpoint URL and appends `/chat/completions` if needed
  - Reuses OpenAI's response parsing logic
  
- Configuration persistence now includes the `customEndpoint` field when applicable
- Updated `isConfigured` check to validate that all required fields are present based on provider type

https://claude.ai/code/session_01JZcakb5TPHUxhzJz5ACLjK